### PR TITLE
Add es2015 lib in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": [ "es2015" ]
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Fix https://github.com/baudev/Nexecur-Unofficial-API/issues/3

Adding `"lib": [ "es2015" ]` in `tsconfig.json` has prevented adding "a declaration for the 'Promise' constructor ".