### PR TITLE
Connection with only the site's id and password

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@types/node": "^10.11.4",
     "request": "^2.88.0",
-    "typescript": "^3.1.1"
+    "typescript": "^3.1.1",
+    "crypto": "^1.0.1"
   },
   "author": "Baudev & Quelqun007",
   "license": "MIT",


### PR DESCRIPTION
This PR is in charge of solving https://github.com/baudev/Nexecur-Unofficial-API/issues/7

The goal of this one is simplify the way of using this unofficial API. Currently, you must specify the following values :
- `id_site`
- the hash of the `password`
- the hash of the `pin`

**When this PR will be done, connection will be possible simply thanks to the `id_site` and `password` (and not the hash!)** 🎉 
 